### PR TITLE
chore(codeowners): Set codeowners for historical proofs work stream

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,44 +1,10 @@
-*                           @gakonst
-crates/blockchain-tree-api/ @rakita @rkrasiuk @mattsse @Rjected
-crates/blockchain-tree/     @rakita @rkrasiuk @mattsse @Rjected
-crates/chain-state/         @fgimenez @mattsse @rkrasiuk
-crates/chainspec/           @Rjected @joshieDo @mattsse
-crates/cli/                 @mattsse
-crates/consensus/           @rkrasiuk @mattsse @Rjected
-crates/e2e-test-utils/      @mattsse @Rjected @klkvr @fgimenez
-crates/engine/              @rkrasiuk @mattsse @Rjected @fgimenez @mediocregopher @yongkangc
-crates/era/                 @mattsse @RomanHodulak
-crates/errors/              @mattsse
-crates/ethereum-forks/      @mattsse @Rjected
-crates/ethereum/            @mattsse @Rjected
-crates/etl/                 @joshieDo @shekhirin
-crates/evm/                 @rakita @mattsse @Rjected
-crates/exex/                @shekhirin
-crates/net/                 @mattsse @Rjected
-crates/net/downloaders/     @rkrasiuk
-crates/node/                @mattsse @Rjected @klkvr
-crates/optimism/            @mattsse @Rjected @fgimenez
-crates/payload/             @mattsse @Rjected
-crates/primitives-traits/   @Rjected @RomanHodulak @mattsse @klkvr
-crates/primitives/          @Rjected @mattsse @klkvr
-crates/prune/               @shekhirin @joshieDo
-crates/ress                 @rkrasiuk
-crates/revm/                @mattsse @rakita
-crates/rpc/                 @mattsse @Rjected @RomanHodulak
-crates/stages/              @rkrasiuk @shekhirin @mediocregopher
-crates/static-file/         @joshieDo @shekhirin
-crates/storage/codecs/      @joshieDo
-crates/storage/db-api/      @joshieDo @rakita
-crates/storage/db-common/   @Rjected
-crates/storage/db/          @joshieDo @rakita
-crates/storage/errors/      @rakita
-crates/storage/libmdbx-rs/  @rakita @shekhirin
-crates/storage/nippy-jar/   @joshieDo @shekhirin
-crates/storage/provider/    @rakita @joshieDo @shekhirin
-crates/storage/storage-api/ @joshieDo @rkrasiuk
-crates/tasks/               @mattsse
-crates/tokio-util/          @fgimenez
-crates/transaction-pool/    @mattsse @yongkangc
-crates/trie/                @rkrasiuk @Rjected @shekhirin @mediocregopher
-etc/                        @Rjected @shekhirin
-.github/                    @gakonst @DaniPopes
+*                           @emhane @theochap @BioMark3r
+crates/blockchain-tree-api/ @dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 @emhane
+crates/blockchain-tree/     @dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 @emhane
+crates/engine/              @dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 @emhane
+crates/exex/                @dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 @emhane
+crates/node/                @dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 @emhane
+crates/optimism/            @dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 @emhane
+crates/rpc/                 @dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 @emhane
+etc/                        @dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 @emhane
+.github/                    @dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 @emhane


### PR DESCRIPTION
@dhyaniarun1993 @itschaindev @sadiq1971 @meyer9 think these are the only crates we will need to touch. can update as we go. ideally the new logic will only live inside of _crates/optimism_, but we may need to generalise some components in the other crates I listed and make them customisable up at SDK (node builder _crates/node_) level to achieve this.